### PR TITLE
fix: restore accessibilityViewIsModal after nested modal dismiss

### DIFF
--- a/Modals/Sources/ModalPresentationViewController.swift
+++ b/Modals/Sources/ModalPresentationViewController.swift
@@ -470,12 +470,24 @@ public final class ModalPresentationViewController: UIViewController {
                 )
             }
 
+        /// Always update `accessibilityViewIsModal` — even when the top layer hasn't changed,
+        /// an exiting presentation may have stolen the flag from the remaining one.
+
+        let views = presentations(includeExiting: false).map(\.containerView)
+
+        views.last?.accessibilityViewIsModal = true
+
+        for view in views.dropLast() {
+            view.accessibilityViewIsModal = false
+        }
+
         /// Note: We can use ! here, because our base `content` is always included in the array; it can never be empty.
 
         let oldTopLayer = oldLayers.last!
         let topLayer = accessibilityLayers.last!
 
         /// If the layering didn't change, then nothing changed, we can bail early.
+        /// (Focus restoration and a11y notifications only matter when the top layer changes.)
 
         guard oldTopLayer != topLayer else {
             return
@@ -485,22 +497,6 @@ public final class ModalPresentationViewController: UIViewController {
 
         if accessibilityLayers.contains(oldTopLayer) {
             focusRestorationStorage.focusRestoration(for: oldTopLayer.viewController).recordFocusedAccessibilityElement()
-        }
-
-        /// Note: We don't restore a11y here, it's done once the
-        /// presentation or dismissal animation is completed after a short delay.
-        ///
-        /// See `postAccessibilityScreenChangedNotification`.
-
-        /// Now we can update our `accessibilityViewIsModal` status.
-        /// This ensures that VoiceOver users only see the top-most modal layer.
-
-        let views = allPresentations.map(\.containerView)
-
-        views.last?.accessibilityViewIsModal = true
-
-        for view in views.dropLast() {
-            view.accessibilityViewIsModal = false
         }
     }
 
@@ -762,6 +758,11 @@ public final class ModalPresentationViewController: UIViewController {
         presentation.decorationViews.forEach { $0.removeFromSuperview() }
 
         allPresentations.removeAll { $0.viewController === presentation.viewController }
+
+        // Re-evaluate accessibilityViewIsModal after removal.
+        // The removed presentation may have held the flag, leaving the
+        // remaining top presentation with accessibilityViewIsModal = false.
+        updateAccessibilityViewIsModal()
     }
 
     private func setUpTransitionIn(presentation: Presentation) {

--- a/Modals/Tests/ModalPresentationViewControllerTests.swift
+++ b/Modals/Tests/ModalPresentationViewControllerTests.swift
@@ -127,6 +127,63 @@ final class ModalPresentationViewControllerTests: XCTestCase {
         }
     }
 
+    // MARK: - Accessibility
+
+    func test_accessibilityViewIsModal_restored_after_nested_dismiss() {
+        let content = UIViewController()
+        let subject = ModalPresentationViewController(content: content)
+
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 800))
+        window.rootViewController = subject
+        window.makeKeyAndVisible()
+
+        let modalA = UIViewController()
+        let modalB = UIViewController()
+
+        // Present modal A
+        subject.update(modals: [modal(for: modalA)])
+
+        // Find modal A's ContainerView
+        let containerViews = subject.view.subviews.filter {
+            String(describing: type(of: $0)).contains("ContainerView")
+        }
+        XCTAssertEqual(containerViews.count, 1, "Expected one ContainerView after presenting modal A")
+        let containerA = containerViews[0]
+        XCTAssertTrue(containerA.accessibilityViewIsModal, "Modal A's ContainerView should have accessibilityViewIsModal = true")
+
+        // Present modal B on top of A
+        subject.update(modals: [modal(for: modalA), modal(for: modalB)])
+
+        // Now modal B's container should be modal, A's should not
+        let containerViewsAfterB = subject.view.subviews.filter {
+            String(describing: type(of: $0)).contains("ContainerView")
+        }
+        XCTAssertEqual(containerViewsAfterB.count, 2, "Expected two ContainerViews after presenting modal B")
+
+        // Dismiss modal B — only A remains
+        subject.update(modals: [modal(for: modalA)])
+
+        // Wait for the exit animation to complete
+        let expectation = expectation(description: "animation")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        // Modal A's ContainerView should have accessibilityViewIsModal restored to true
+        let containerViewsAfterDismiss = subject.view.subviews.filter {
+            String(describing: type(of: $0)).contains("ContainerView")
+        }
+        XCTAssertEqual(containerViewsAfterDismiss.count, 1, "Expected one ContainerView after dismissing modal B")
+        XCTAssertTrue(
+            containerViewsAfterDismiss[0].accessibilityViewIsModal,
+            "BUG: Modal A's ContainerView has accessibilityViewIsModal = false after nested dismiss. Parent screen elements will leak through."
+        )
+
+        window.resignKey()
+        window.isHidden = true
+    }
+
     func modal(for vc: UIViewController) -> PresentableModal {
         PresentableModal(
             viewController: vc,

--- a/Modals/Tests/ModalPresentationViewControllerTests.swift
+++ b/Modals/Tests/ModalPresentationViewControllerTests.swift
@@ -149,7 +149,10 @@ final class ModalPresentationViewControllerTests: XCTestCase {
         }
         XCTAssertEqual(containerViews.count, 1, "Expected one ContainerView after presenting modal A")
         let containerA = containerViews[0]
-        XCTAssertTrue(containerA.accessibilityViewIsModal, "Modal A's ContainerView should have accessibilityViewIsModal = true")
+        XCTAssertTrue(
+            containerA.accessibilityViewIsModal,
+            "Modal A's ContainerView should have accessibilityViewIsModal = true"
+        )
 
         // Present modal B on top of A
         subject.update(modals: [modal(for: modalA), modal(for: modalB)])


### PR DESCRIPTION
## Summary

When a modal is presented on top of another modal and then dismissed, the remaining modal's `ContainerView` is left with `accessibilityViewIsModal = false`. This causes VoiceOver to expose elements from both the modal and the underlying parent screen — doubling every element visible to assistive technology.

**Before fix** — after dismissing a nested modal:
- `accessibilityViewIsModal` on the remaining modal's `ContainerView` is `false`
- Parent screen elements leak through the modal mask
- VoiceOver users see duplicated elements with no way to distinguish layers

**After fix:**
- `accessibilityViewIsModal` is correctly restored to `true`
- Only the top modal's elements are visible to VoiceOver

## Root cause

Three issues in `ModalPresentationViewController`:

### 1. Flag assignment included exiting presentations

`updateAccessibilityViewIsModal()` used `allPresentations.map(\.containerView)` which includes presentations in `.pendingExit` and `.exiting` states. The exiting presentation's `ContainerView` becomes `.last` and receives the flag, while the remaining presentation's container is set to `false`.

### 2. Early-return guard prevented re-evaluation

```swift
guard oldTopLayer != topLayer else {
    return // Flag assignment was below this — never reached
}
```

When the nested modal dismisses, the top accessibility layer returns to the same presentation that was on top before. The guard bails, skipping the flag assignment.

### 3. `remove(presentation:)` didn't re-evaluate the flag

After the exit animation completes, `remove(presentation:)` removes the presentation from `allPresentations` but never calls `updateAccessibilityViewIsModal()`. The remaining container keeps its `false` value permanently.

## Fix

1. **Move the flag assignment above the early-return guard** so it runs unconditionally
2. **Use `presentations(includeExiting: false)`** to exclude exiting presentations
3. **Call `updateAccessibilityViewIsModal()` from `remove(presentation:)`** to restore the flag after removal

## Commits

1. **`test:`** Adds a failing test that reproduces the bug — presents modal A, presents modal B on top, dismisses B, asserts `accessibilityViewIsModal` is `true` on A's `ContainerView`. Fails without the fix.
2. **`fix:`** Makes the test pass. 46/46 unit tests green.

## Reproduction

1. Present a full-screen modal
2. From within that modal, present a second modal (any style)
3. Dismiss the second modal
4. The first modal's `ContainerView` now has `accessibilityViewIsModal = false`
5. VoiceOver can navigate to elements behind the modal that should be hidden

## Test plan

- [x] Test fails without fix (`accessibilityViewIsModal = false`)
- [x] Test passes with fix (`accessibilityViewIsModal = true`)
- [x] Full unit test suite passes (46/46)
- [ ] VoiceOver manual verification after nested dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)