### PR TITLE
fix: Defer detached modal toast host updates

### DIFF
--- a/WorkflowModals/Sources/AnyModalToastContainer.swift
+++ b/WorkflowModals/Sources/AnyModalToastContainer.swift
@@ -187,12 +187,15 @@ public final class AnyModalToastContainerViewController: ScreenViewController<An
         }
 
         guard let host = modalHost else {
-
             // If we're not installed the view controller hierarchy, we don't expect to find a
             // host, but if we are and we don't have a modal host, that's a programmer error
             // since we cannot present our modals.
 
             guard isViewLoaded else {
+                return
+            }
+
+            guard parent != nil else {
                 return
             }
 

--- a/WorkflowModals/Tests/ModalContainerTests.swift
+++ b/WorkflowModals/Tests/ModalContainerTests.swift
@@ -193,6 +193,69 @@ final class ModalContainerTests: XCTestCase {
             }
         }
     }
+
+    func test_modal_host_update_defers_when_view_has_window_without_parent() throws {
+        class HostViewController: UIViewController, ModalHost {
+
+            var updateModalsCount = 0
+            var aggregatedModalCount = 0
+
+            func setNeedsModalUpdate() {
+                updateModalsCount += 1
+                aggregatedModalCount = aggregateModals().modals.count
+            }
+        }
+
+        let modalScreen = ModalContainer<EmptyScreen, EmptyScreen>(
+            base: EmptyScreen(),
+            modals: []
+        )
+
+        let description = modalScreen.viewControllerDescription(environment: .empty)
+        let viewController = try XCTUnwrap(description.buildViewController() as? AnyModalToastContainerViewController)
+
+        let host = HostViewController()
+
+        show(vc: host) { host in
+            viewController.view.frame = host.view.bounds
+            host.view.addSubview(viewController.view)
+
+            XCTAssertNil(viewController.parent)
+            XCTAssertNotNil(viewController.view.window)
+
+            let updatedScreen = ModalContainer(
+                base: EmptyScreen(),
+                modals: [
+                    Modal(
+                        key: "first-modal",
+                        style: FullScreenModalStyle(),
+                        content: EmptyScreen()
+                    ),
+                ]
+            )
+
+            updatedScreen.viewControllerDescription(environment: .empty)
+                .update(viewController: viewController)
+            viewController.view.layoutIfNeeded()
+
+            XCTAssertEqual(host.updateModalsCount, 0)
+
+            viewController.view.removeFromSuperview()
+            host.addChild(viewController)
+            host.view.addSubview(viewController.view)
+            viewController.didMove(toParent: host)
+
+            viewController.view.setNeedsLayout()
+            viewController.view.layoutIfNeeded()
+
+            XCTAssertEqual(host.updateModalsCount, 1)
+            XCTAssertEqual(host.aggregatedModalCount, 1)
+
+            viewController.willMove(toParent: nil)
+            viewController.view.removeFromSuperview()
+            viewController.removeFromParent()
+        }
+    }
 }
 
 extension ModalContainerTests {


### PR DESCRIPTION
## Checklist

- [x] Unit Tests
- [x] Documentation

## Summary

`AnyModalToastContainerViewController` can receive modal-host updates after its UIKit parent has been detached but before its view has left the window. That transient state can happen during SwiftUI-driven updates and teardown, causing the missing-parent modal-host assertion to fire even though there is no host to notify yet.

This defers modal-host updates while the container has no parent, matching the existing deferrals for unloaded and windowless views. The pending update is preserved and retried once the container is attached again.

## Validation

- `swiftformat --lint WorkflowModals/Sources/AnyModalToastContainer.swift WorkflowModals/Tests/ModalContainerTests.swift`
- `tuist test --path Samples UnitTests`
