### PR TITLE
feat: add HostToastPresenting for host-scoped toast presentation

### DIFF
--- a/Modals/Sources/ModalHostContainerViewController.swift
+++ b/Modals/Sources/ModalHostContainerViewController.swift
@@ -343,6 +343,15 @@ public final class ModalHostContainerViewController: UIViewController, ModalHost
     }
 }
 
+extension ModalHostContainerViewController: HostToastPresenting {
+
+    /// A `ToastPresenter` that presents toasts from the root of this host's content. See
+    /// [HostToastPresenting](x-source-tag://HostToastPresenting).
+    public var contentToastPresenter: ToastPresenter {
+        content.toastPresenter
+    }
+}
+
 private final class ModalHostView: UIView {
     private let passthroughSizeThatFits: (CGSize) -> CGSize
     private let ancestorPresentationView: () -> UIView?

--- a/Modals/Sources/Toasts/HostToastPresenting.swift
+++ b/Modals/Sources/Toasts/HostToastPresenting.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+
+/// A [ModalHost](x-source-tag://ModalHost) that can provide a `ToastPresenter` for presenting
+/// toasts scoped to the host, rather than to the presenting view controller.
+///
+/// Toasts presented through `contentToastPresenter` are owned by the host's content, so their
+/// lifetime is decoupled from the view controller that triggered them: they remain presented
+/// across navigation — including removal of the triggering view controller from the hierarchy —
+/// until dismissed via their `ModalLifetime`, or until the host's content itself leaves the
+/// hierarchy. Use this for fire-and-forget notification toasts, such as a toast presented while
+/// the screen that triggered it is being popped.
+///
+/// To scope a toast's lifetime to a particular view controller instead, use that view
+/// controller's `toastPresenter`.
+///
+/// You can reach a host from any descendent view controller via `modalHost` or `rootModalHost`:
+///
+/// ```swift
+/// if let host = rootModalHost as? HostToastPresenting {
+///     self.toastLifetime = host.contentToastPresenter.present(toastViewController)
+/// }
+/// ```
+///
+/// - Tag: HostToastPresenting
+///
+public protocol HostToastPresenting: ModalHost {
+
+    /// A `ToastPresenter` that presents toasts from the root of the host's content, decoupling
+    /// their lifetime from any particular descendent view controller.
+    var contentToastPresenter: ToastPresenter { get }
+}

--- a/Modals/Sources/Toasts/HostToastPresenting.swift
+++ b/Modals/Sources/Toasts/HostToastPresenting.swift
@@ -2,14 +2,22 @@ import UIKit
 
 
 /// A [ModalHost](x-source-tag://ModalHost) that can provide a `ToastPresenter` for presenting
-/// toasts scoped to the host, rather than to the presenting view controller.
+/// toasts scoped to the host's content, rather than to the presenting view controller.
 ///
-/// Toasts presented through `contentToastPresenter` are owned by the host's content, so their
-/// lifetime is decoupled from the view controller that triggered them: they remain presented
-/// across navigation — including removal of the triggering view controller from the hierarchy —
-/// until dismissed via their `ModalLifetime`, or until the host's content itself leaves the
-/// hierarchy. Use this for fire-and-forget notification toasts, such as a toast presented while
-/// the screen that triggered it is being popped.
+/// Toasts presented through `contentToastPresenter` are stored by the host's content, so removing
+/// the triggering view controller from the hierarchy (e.g. with a navigation pop) does not dismiss
+/// them. As with any toast presentation, the returned `ModalLifetime` must be retained —
+/// deallocating it dismisses the toast — so retain it with an owner that outlives the triggering
+/// view controller.
+///
+/// Storage and visibility have separate lifetimes: retaining the `ModalLifetime` keeps the toast
+/// stored by the content presenter, while the toast is visible only when the host is attached to
+/// an active modal-host hierarchy. Detaching a nested host removes its forwarded toast from the
+/// former ancestor without dismissing the retained lifetime.
+///
+/// Presented toasts participate in the host's presentation filter like any other toast within
+/// its content: with the default pass-through-toasts filter, a nested host forwards them to its
+/// ancestor, so they are displayed by the outermost host.
 ///
 /// To scope a toast's lifetime to a particular view controller instead, use that view
 /// controller's `toastPresenter`.
@@ -17,8 +25,22 @@ import UIKit
 /// You can reach a host from any descendent view controller via `modalHost` or `rootModalHost`:
 ///
 /// ```swift
-/// if let host = rootModalHost as? HostToastPresenting {
-///     self.toastLifetime = host.contentToastPresenter.present(toastViewController)
+/// final class ToastCoordinator {
+///     private var toastLifetime: ModalLifetime?
+///
+///     func present(
+///         _ toastViewController: some UIViewController & ToastPresentable,
+///         from trigger: UIViewController
+///     ) {
+///         guard let host = trigger.rootModalHost as? HostToastPresenting else { return }
+///
+///         toastLifetime = host.contentToastPresenter.present(toastViewController)
+///     }
+///
+///     func dismissToast() {
+///         toastLifetime?.dismiss()
+///         toastLifetime = nil
+///     }
 /// }
 /// ```
 ///

--- a/Modals/Tests/HostToastPresentingTests.swift
+++ b/Modals/Tests/HostToastPresentingTests.swift
@@ -1,0 +1,71 @@
+import TestingSupport
+import UIKit
+import XCTest
+@testable import Modals
+
+final class HostToastPresentingTests: XCTestCase {
+
+    func test_presents_from_host_content() {
+        let content = UIViewController()
+        let host = ModalHostContainerViewController(content: content)
+
+        let lifetime = host.contentToastPresenter.present(
+            UIViewController(),
+            style: .init(ToastPresentationStyleFixture()),
+            accessibilityAnnouncement: "Toast."
+        )
+
+        // The toast is owned by the host's content, making it visible to the host's aggregation.
+        XCTAssertEqual(content.aggregateModals().toasts.count, 1)
+
+        show(vc: host) { host in
+            XCTAssertTrue(host.toastPresentation.hasVisiblePresentations)
+
+            lifetime.dismiss()
+            XCTAssertEqual(content.aggregateModals().toasts.count, 0)
+        }
+    }
+
+    func test_toast_outlives_presenting_descendent() {
+        let content = UIViewController()
+        let screen = UIViewController()
+        content.addChild(screen)
+        content.view.addSubview(screen.view)
+        screen.didMove(toParent: content)
+
+        let host = ModalHostContainerViewController(content: content)
+
+        let lifetime = host.contentToastPresenter.present(
+            UIViewController(),
+            style: .init(ToastPresentationStyleFixture()),
+            accessibilityAnnouncement: "Toast."
+        )
+        defer { lifetime.dismiss() }
+
+        // Remove the view controller that triggered the toast, as a navigation pop would.
+        screen.willMove(toParent: nil)
+        screen.view.removeFromSuperview()
+        screen.removeFromParent()
+
+        XCTAssertEqual(
+            content.aggregateModals().toasts.count,
+            1,
+            "The toast should remain presented after the triggering view controller is removed."
+        )
+    }
+
+    func test_host_is_reachable_from_descendents() {
+        let content = UIViewController()
+        let screen = UIViewController()
+        content.addChild(screen)
+        content.view.addSubview(screen.view)
+        screen.didMove(toParent: content)
+
+        let host = ModalHostContainerViewController(content: content)
+
+        show(vc: host) { host in
+            let found = screen.rootModalHost as? HostToastPresenting
+            XCTAssertTrue(found === host)
+        }
+    }
+}

--- a/Modals/Tests/HostToastPresentingTests.swift
+++ b/Modals/Tests/HostToastPresentingTests.swift
@@ -26,32 +26,110 @@ final class HostToastPresentingTests: XCTestCase {
         }
     }
 
-    func test_toast_outlives_presenting_descendent() {
+    func test_toast_outlives_presenting_descendent() throws {
         let content = UIViewController()
-        let screen = UIViewController()
-        content.addChild(screen)
-        content.view.addSubview(screen.view)
-        screen.didMove(toParent: content)
-
+        weak var weakScreen: UIViewController?
         let host = ModalHostContainerViewController(content: content)
 
-        let lifetime = host.contentToastPresenter.present(
-            UIViewController(),
-            style: .init(ToastPresentationStyleFixture()),
-            accessibilityAnnouncement: "Toast."
-        )
-        defer { lifetime.dismiss() }
+        func presentFromDescendent() throws -> ModalLifetime {
+            let screen = UIViewController()
+            weakScreen = screen
+            content.addChild(screen)
+            content.view.addSubview(screen.view)
+            screen.didMove(toParent: content)
 
-        // Remove the view controller that triggered the toast, as a navigation pop would.
-        screen.willMove(toParent: nil)
-        screen.view.removeFromSuperview()
-        screen.removeFromParent()
+            // Resolve the host from the triggering view controller, as a consumer would, and
+            // return the lifetime to an owner outside it.
+            let resolvedHost = try XCTUnwrap(screen.rootModalHost as? HostToastPresenting)
+            let lifetime = resolvedHost.contentToastPresenter.present(
+                UIViewController(),
+                style: .init(ToastPresentationStyleFixture()),
+                accessibilityAnnouncement: "Toast."
+            )
+
+            // Remove the view controller that triggered the toast, as a navigation pop would.
+            screen.willMove(toParent: nil)
+            screen.view.removeFromSuperview()
+            screen.removeFromParent()
+
+            return lifetime
+        }
+
+        let lifetime = try presentFromDescendent()
+
+        XCTAssertNil(weakScreen)
 
         XCTAssertEqual(
             content.aggregateModals().toasts.count,
             1,
             "The toast should remain presented after the triggering view controller is removed."
         )
+
+        show(vc: host) { host in
+            XCTAssertTrue(host.toastPresentation.hasVisiblePresentations)
+
+            lifetime.dismiss()
+            host.view.layoutIfNeeded()
+
+            XCTAssertTrue(host.toastPresentation.presentedViewControllers.isEmpty)
+        }
+    }
+
+    func test_nested_host_forwards_toasts_to_ancestor_by_default() {
+        let innerContent = UIViewController()
+        let innerHost = ModalHostContainerViewController(content: innerContent)
+
+        let outerContent = UIViewController()
+        outerContent.addChild(innerHost)
+        outerContent.view.addSubview(innerHost.view)
+        innerHost.didMove(toParent: outerContent)
+
+        let outerHost = ModalHostContainerViewController(content: outerContent)
+
+        let lifetime = innerHost.contentToastPresenter.present(
+            UIViewController(),
+            style: .init(ToastPresentationStyleFixture()),
+            accessibilityAnnouncement: "Toast."
+        )
+        defer { lifetime.dismiss() }
+
+        show(vc: outerHost) { outerHost in
+            innerHost.view.layoutIfNeeded()
+
+            // The default pass-through-toasts filter forwards the toast to the ancestor host.
+            XCTAssertFalse(innerHost.toastPresentation.hasVisiblePresentations)
+            XCTAssertTrue(outerHost.toastPresentation.hasVisiblePresentations)
+        }
+    }
+
+    func test_nested_host_presents_toasts_locally_when_not_passing_through() {
+        let innerContent = UIViewController()
+        let innerHost = ModalHostContainerViewController(
+            content: innerContent,
+            shouldPassthroughToasts: false
+        )
+
+        let outerContent = UIViewController()
+        outerContent.addChild(innerHost)
+        outerContent.view.addSubview(innerHost.view)
+        innerHost.didMove(toParent: outerContent)
+
+        let outerHost = ModalHostContainerViewController(content: outerContent)
+
+        let lifetime = innerHost.contentToastPresenter.present(
+            UIViewController(),
+            style: .init(ToastPresentationStyleFixture()),
+            accessibilityAnnouncement: "Toast."
+        )
+        defer { lifetime.dismiss() }
+
+        show(vc: outerHost) { outerHost in
+            innerHost.view.layoutIfNeeded()
+
+            // Without the pass-through filter, the inner host displays its own toasts.
+            XCTAssertTrue(innerHost.toastPresentation.hasVisiblePresentations)
+            XCTAssertFalse(outerHost.toastPresentation.hasVisiblePresentations)
+        }
     }
 
     func test_host_is_reachable_from_descendents() {

--- a/WorkflowModals/Sources/ModalHostContainer.swift
+++ b/WorkflowModals/Sources/ModalHostContainer.swift
@@ -141,7 +141,9 @@ extension ModalHostContainer: Screen where Content: Screen {
 
     // TODO: This should be extracted from `ModalHostContainer<Content>` so its type isnt dependent on `<Content>`.
 
-    final class ViewController: ScreenViewController<ModalHostContainer>, ModalHost, ToastPresentationViewControllerDelegate {
+    final class ViewController: ScreenViewController<ModalHostContainer>, ModalHost, HostToastPresenting,
+        ToastPresentationViewControllerDelegate
+    {
         private(set) var content: UIViewController
         let modalPresentationController: ModalPresentationViewController
         let toastPresentationController: ToastPresentationViewController
@@ -326,6 +328,14 @@ extension ModalHostContainer: Screen where Content: Screen {
             // Some modals should be forwarded. Pass them through to aggregation.
             let modalList = content.aggregateModals()
             return presentationFilter.presentedByAncestor(modalList)
+        }
+
+        // MARK: HostToastPresenting
+
+        /// A `ToastPresenter` that presents toasts from the root of this host's content. See
+        /// [HostToastPresenting](x-source-tag://HostToastPresenting).
+        var contentToastPresenter: ToastPresenter {
+            content.toastPresenter
         }
 
         private var ancestorModalHost: ModalHost? {

--- a/WorkflowModals/Tests/ModalHostContainerTests.swift
+++ b/WorkflowModals/Tests/ModalHostContainerTests.swift
@@ -574,6 +574,33 @@ class ModalHostContainerTests: XCTestCase {
         hostContainer.view.layoutIfNeeded()
         XCTAssertEqual(hostContainer.preferredContentSize, CGSize(width: axisSize, height: axisSize))
     }
+    func test_host_toast_presenter_presents_from_content() {
+        let viewController = ModalHostContainer.ViewController(
+            screen: .init(
+                content: EmptyScreen(),
+                toastContainerStyle: .fixture
+            ),
+            environment: .empty
+        )
+
+        let host: HostToastPresenting = viewController
+
+        let lifetime = host.contentToastPresenter.present(
+            UIViewController(),
+            style: .init(ToastPresentationStyleFixture()),
+            accessibilityAnnouncement: "Toast."
+        )
+
+        // The toast is owned by the host's content, making it visible to the host's aggregation.
+        XCTAssertEqual(viewController.content.aggregateModals().toasts.count, 1)
+
+        show(vc: viewController) { viewController in
+            XCTAssertTrue(viewController.toastPresentationController.hasVisiblePresentations)
+
+            lifetime.dismiss()
+            XCTAssertEqual(viewController.content.aggregateModals().toasts.count, 0)
+        }
+    }
 
     private func makeToastHost() -> ModalHostContainer<EmptyScreen>.ViewController {
         ModalHostContainer.ViewController(

--- a/WorkflowModals/Tests/ModalHostContainerTests.swift
+++ b/WorkflowModals/Tests/ModalHostContainerTests.swift
@@ -574,6 +574,7 @@ class ModalHostContainerTests: XCTestCase {
         hostContainer.view.layoutIfNeeded()
         XCTAssertEqual(hostContainer.preferredContentSize, CGSize(width: axisSize, height: axisSize))
     }
+
     func test_host_toast_presenter_presents_from_content() {
         let viewController = ModalHostContainer.ViewController(
             screen: .init(
@@ -602,11 +603,58 @@ class ModalHostContainerTests: XCTestCase {
         }
     }
 
-    private func makeToastHost() -> ModalHostContainer<EmptyScreen>.ViewController {
+    func test_nested_host_toast_presenter_forwards_to_ancestor_by_default() throws {
+        let innerHost = makeToastHost()
+        let outerHost = makeToastHost()
+        nest(innerHost, in: outerHost)
+
+        let resolvedHost = try XCTUnwrap(innerHost.content.modalHost as? HostToastPresenting)
+        XCTAssertTrue((resolvedHost as? UIViewController) === innerHost)
+        XCTAssertTrue((innerHost.content.rootModalHost as? UIViewController) === outerHost)
+
+        let lifetime = resolvedHost.contentToastPresenter.present(
+            UIViewController(),
+            style: .init(ToastPresentationStyleFixture()),
+            accessibilityAnnouncement: "Toast."
+        )
+        defer { lifetime.dismiss() }
+
+        show(vc: outerHost) { outerHost in
+            innerHost.view.layoutIfNeeded()
+
+            XCTAssertTrue(innerHost.toastPresentationController.presentedViewControllers.isEmpty)
+            XCTAssertEqual(outerHost.toastPresentationController.presentedViewControllers.count, 1)
+        }
+    }
+
+    func test_nested_host_toast_presenter_presents_locally_without_passthrough() {
+        let innerHost = makeToastHost(shouldPassthroughToasts: false)
+        let outerHost = makeToastHost()
+        nest(innerHost, in: outerHost)
+
+        let lifetime = innerHost.contentToastPresenter.present(
+            UIViewController(),
+            style: .init(ToastPresentationStyleFixture()),
+            accessibilityAnnouncement: "Toast."
+        )
+        defer { lifetime.dismiss() }
+
+        show(vc: outerHost) { outerHost in
+            innerHost.view.layoutIfNeeded()
+
+            XCTAssertEqual(innerHost.toastPresentationController.presentedViewControllers.count, 1)
+            XCTAssertTrue(outerHost.toastPresentationController.presentedViewControllers.isEmpty)
+        }
+    }
+
+    private func makeToastHost(
+        shouldPassthroughToasts: Bool = true
+    ) -> ModalHostContainer<EmptyScreen>.ViewController {
         ModalHostContainer.ViewController(
             screen: .init(
                 content: EmptyScreen(),
-                toastContainerStyle: .fixture
+                toastContainerStyle: .fixture,
+                shouldPassthroughToasts: shouldPassthroughToasts
             ),
             environment: .empty
         )


### PR DESCRIPTION
> **Stack:** This feature is based on #16, which contains the general forwarded-presentation invalidation fix and its lifecycle tests. This PR now contains only the `HostToastPresenting` API, documentation, and toast-specific owner-resolution coverage.

## Overview

Adds a `HostToastPresenting` protocol that modal hosts conform to, vending a `ToastPresenter` (`contentToastPresenter`) that presents toasts from the root of the host's content — decoupling toast lifetimes from the view controller that triggered them.

## Motivation

Toasts are fire-and-forget notifications: the canonical flows ("Item saved" while popping a screen, "Item deleted" while a sheet closes) present a toast precisely when the triggering UI is going away. Today's imperative path scopes toast lifetime to the presenting view controller — `viewController.toastPresenter.present(...)` stops being aggregated the moment that view controller leaves the hierarchy.

The only current workaround is to walk the view controller hierarchy to find the view controller at the base of the host's content and present from it, which requires knowledge of the modal presentation system's internal container types. (MarketSwiftUI's in-progress toast API does exactly this walk today — see squareup/market#12597 — and this API would let it delete that code.)

Presenting from the host itself doesn't work either: hosts aggregate starting at their *content* (`content.aggregateModals()`), so anything presented from the host's own presenter is never aggregated.

## Design

```swift
public protocol HostToastPresenting: ModalHost {
    /// A `ToastPresenter` that presents toasts from the root of the host's content, decoupling
    /// their lifetime from any particular descendent view controller.
    var contentToastPresenter: ToastPresenter { get }
}
```

Both hosts conform by delegating to their content's existing presenter (`content.toastPresenter`), so environment propagation, presentation filters, toast ordering, and lifetime semantics are exactly those of any content-presented toast — no aggregation or behavioral changes. The WorkflowModals host class is internal, so the protocol is the public surface; consumers reach it from any descendent view controller:

```swift
if let host = rootModalHost as? HostToastPresenting {
    self.toastLifetime = host.contentToastPresenter.present(toastViewController)
}
```

`HostToastPresenting` is a separate protocol (rather than a `ModalHost` requirement) because `ModalHost` is `@objc` and can't gain a defaulted Swift requirement, and `ToastPresenter` is not `@objc`-representable.

## Notes

- Nested hosts ride the existing rails: the default `passThroughToasts` filter already forwards toasts to the outermost host.
- Naming: `contentToastPresenter` rather than `toastPresenter` because `UIViewController.toastPresenter` already exists on host view controllers with different semantics (the host's own — never-aggregated — presenter).

## Alternatives considered

**App-installed root anchor ("hoist it yourself").** The framework's standing guidance for toast-lifetime pain has been to present from a long-lived view controller you own, and an app *can* install its own anchor at its content root with no framework change. Two reasons that doesn't generalize: in Workflow apps the host's content view controller is internal to `WorkflowModals`, so there is no uniform way for a library (as opposed to each app) to reach a long-lived presentation point; and per-app root wiring produces N slightly-different implementations of the same thing. This PR is the one-line framework capability that makes the hoisting pattern implementable uniformly.

**Host aggregates its own presenter.** A ~2-line change (`content.aggregateModals() + self.aggregatePresenterModals()`) would make `host.toastPresenter` functional directly. Rejected for its side effects: it would resurrect any currently black-holed presentations sitting in host trampolines after an upgrade; host-owned items would resolve `ViewEnvironment` from the host rather than the content subtree (wrong theming); it would implicitly legitimize host-level *modals*; and it needs a defined path through the WorkflowModals presentation-filter forwarding. Delegating to the content's existing presenter sidesteps all of that — semantics are byte-for-byte those of a content-presented toast.

**First-class host-owned toast presentation.** The fuller design: the host owns imperative toast state directly (no trampoline, no aggregation dependency for display), retains presentations until dismissal (no drop-to-dismiss token footgun), and treats a missing host as a defined best-effort no-op rather than `fatalError` — toasts, unlike modals, leave no undefined state behind when presentation fails. That's a real architectural conversation (host-owned mutable state alongside the aggregation model, environment propagation for host-owned presentations), not a small PR — a working-draft design doc for it is up at #14. This accessor is deliberately compatible with it: `contentToastPresenter` can later be reimplemented on top of host-owned presentation — or deprecated in its favor — without breaking adopters.

## Known trade-offs

- **Attribution.** Toasts presented through this accessor are owned by the host's content, so the view controller hierarchy no longer identifies which feature presented a given toast. Acceptable for transient notifications, but worth noting; a first-class API (above) could carry explicit source attribution.
- **Capability by downcast.** `rootModalHost as? HostToastPresenting` exists because `ModalHost` is `@objc` and can't carry a defaulted Swift requirement (and `ToastPresenter` isn't `@objc`-representable). A host that doesn't conform quietly lacks the capability; both in-tree hosts conform.
- **Scoping is inherited, not chosen.** The accessor rides existing presentation-filter semantics (pass-through forwards toasts to the outermost host). Callers choosing between `modalHost` and `rootModalHost` pick a starting point, not a display guarantee — the filter decides. Documented on the protocol.

## Checklist

- [x] Unit Tests
- [x] Documentation
- [x] Pull request title follows conventional commits