### PR TITLE
Update Workflow to 6.0 and account for ReactiveSwift removal

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,14 +5,12 @@ on:
     branches: [ main ]
 
 env:
-  # Xcode 16.3 gets us Swift 6.1, required for docc merge
-  XCODE_VERSION: 16.3
+  XCODE_VERSION: 26.5
 
 jobs:
   build:
     name: Generate API docs and publish to GitHub pages
-    # macos-15 is required for Xcode 16.3
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -7,10 +7,10 @@ on:
   pull_request:
 
 env:
-  XCODE_VERSION: 26.2
-  TUIST_TEST_DEVICE: iPad (10th generation)
+  XCODE_VERSION: 26.5
+  TUIST_TEST_DEVICE: iPad Pro 11-inch (M5)
   TUIST_TEST_PLATFORM: iOS
-  TUIST_TEST_OS: 18.6
+  TUIST_TEST_OS: 26.2
 
 jobs:
   development-tests:

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log", from: "1.4.4"),
         .package(url: "https://github.com/square/swift-keyboard-observer", from: "1.1.0"),
-        .package(url: "https://github.com/square/workflow-swift", "4.0.1"..<"6.0.0"),
+        .package(url: "https://github.com/square/workflow-swift", from: "6.0.0"),
     ],
     targets: [
         .target(

--- a/Samples/Tuist/Package.resolved
+++ b/Samples/Tuist/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "19b7263bacb9751f151ec0c93ec816fe1ef67c7b",
-        "version" : "1.6.1"
+        "revision" : "794f4b0a9cf32042592388d014f6a1ea987d323a",
+        "version" : "1.9.1"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "671fa54b279fd73933b4a8b34782ebf6c8869145",
-        "version" : "1.5.1"
+        "revision" : "d924c62a70fca5f43872f286dbd7cef0957f1c01",
+        "version" : "1.6.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/square/workflow-swift",
       "state" : {
-        "revision" : "53fc18d87e1785891b64f2dda782bae47f595399",
-        "version" : "4.0.1"
+        "revision" : "d31ae0d61ccd0e41be5b45c299696f087445da2d",
+        "version" : "6.0.0"
       }
     },
     {

--- a/WorkflowModals/Sources/WorkflowModalListProvider.swift
+++ b/WorkflowModals/Sources/WorkflowModalListProvider.swift
@@ -1,6 +1,5 @@
 import Combine
 import Modals
-import ReactiveSwift
 import ViewEnvironment
 import Workflow
 import WorkflowUI
@@ -20,11 +19,11 @@ final class WorkflowModalListProvider<WorkflowType, ModalContent, ToastContent>:
 
     private let workflowHost: WorkflowHost<RootWorkflow<WorkflowType.Rendering, WorkflowType.Output>>
 
-    private let (lifetime, token) = Lifetime.make()
-
     private let manager = Manager()
 
     private let _modalListDidChange = PassthroughSubject<Void, Never>()
+
+    private var cancellables: Set<AnyCancellable> = []
 
     private var contents: Manager.Contents {
         didSet { update() }
@@ -40,27 +39,25 @@ final class WorkflowModalListProvider<WorkflowType, ModalContent, ToastContent>:
     ) {
         workflowHost = .init(workflow: RootWorkflow(workflow))
 
-        workflowHost.output
-            .signal
-            .take(during: lifetime)
-            .observeValues(onOutput)
+        workflowHost.outputPublisher
+            .sink(receiveValue: onOutput)
+            .store(in: &cancellables)
 
         contents = .init(
-            modals: workflowHost.rendering.value.modals,
-            toasts: workflowHost.rendering.value.toasts
+            modals: workflowHost.rendering.modals,
+            toasts: workflowHost.rendering.toasts
         )
         workflowHost
-            .rendering
-            .signal
-            .take(during: lifetime)
-            .observeValues { [weak self] value in
+            .renderingPublisher
+            .dropFirst()
+            .sink { [weak self] value in
                 guard let self else { return }
 
                 contents = .init(
                     modals: value.modals,
                     toasts: value.toasts
                 )
-            }
+            }.store(in: &cancellables)
     }
 
     func update(environment: ViewEnvironment) {


### PR DESCRIPTION
Bump Workflow to 6.0 and address the ReactiveSwift removal from https://github.com/square/workflow-swift/pull/392
